### PR TITLE
types seperated (backend)

### DIFF
--- a/src/backend/events/ipc/core.ts
+++ b/src/backend/events/ipc/core.ts
@@ -1,11 +1,7 @@
 import tabEvents from "./tab";
 import windowEvents from "./window";
 import Window from "../../models/Window";
-import Tablist from "../../models/Tablist";
-
-interface HandlerProps {
-  tablist: Tablist;
-}
+import { HandlerProps } from "../../types/index";
 
 const handler = (window: Window, props: HandlerProps) => {
   windowEvents(window);

--- a/src/backend/events/ipc/tab.ts
+++ b/src/backend/events/ipc/tab.ts
@@ -1,11 +1,7 @@
-import { BrowserView, ipcMain, IpcMainEvent } from "electron";
+import { ipcMain, IpcMainEvent } from "electron";
 
 import Window from "../../models/Window";
-import Tablist from "../../models/Tablist";
-
-interface HandlerProps {
-  tablist: Tablist;
-}
+import { HandlerProps } from "../../types/index";
 
 const handlers = (window: Window, props: HandlerProps) => {
   const { tablist } = props;

--- a/src/backend/models/Tab.ts
+++ b/src/backend/models/Tab.ts
@@ -1,18 +1,8 @@
 import { BrowserView, IpcMainEvent } from "electron";
+import { TabProps } from "../types";
 
 import Tablist from "./Tablist";
 import defaults from "../lib/defaults";
-
-interface TabProps {
-  id: number;
-  url: string;
-  friendlyUrl: string;
-  view: BrowserView;
-  title?: string;
-  favicon?: string;
-  active?: boolean;
-  engine?: string;
-}
 
 class Tab {
   id: number;
@@ -43,23 +33,26 @@ class Tab {
   }
 
   eventHandler(tablist: Tablist, event: IpcMainEvent) {
-    this.view.webContents.on("page-title-updated", (e, title) => {
+    this.view.webContents.on("page-title-updated", (e: any, title: string) => {
       if (title) {
         this.setTitle(title);
         event.reply("update-tabs", tablist.getFriendlyTabs());
       }
     });
-    this.view.webContents.on("page-favicon-updated", (e, favicons) => {
-      if (favicons.length) {
-        this.setFavicon(favicons[0]);
-        event.reply("update-tabs", tablist.getFriendlyTabs());
+    this.view.webContents.on(
+      "page-favicon-updated",
+      (e: any, favicons: any) => {
+        if (favicons.length) {
+          this.setFavicon(favicons[0]);
+          event.reply("update-tabs", tablist.getFriendlyTabs());
+        }
       }
-    });
-    this.view.webContents.on("did-navigate", (e, url) => {
+    );
+    this.view.webContents.on("did-navigate", (e: any, url: string) => {
       this.setURL(url);
       event.reply("update-tabs", tablist.getFriendlyTabs());
     });
-    this.view.webContents.on("did-navigate-in-page", (e, url) => {
+    this.view.webContents.on("did-navigate-in-page", (e: any, url: string) => {
       this.setURL(url);
       event.reply("update-tabs", tablist.getFriendlyTabs());
     });

--- a/src/backend/models/Tablist.ts
+++ b/src/backend/models/Tablist.ts
@@ -3,6 +3,8 @@ import { BrowserView, IpcMainEvent } from "electron";
 import Tab from "./Tab";
 import Window from "./Window";
 
+import { FriendlyTabProps } from "../types/index";
+
 class Tablist {
   tablist: Tab[];
   history: Tab[];
@@ -49,16 +51,6 @@ class Tablist {
   }
 
   getFriendlyTabs(): object[] {
-    interface FriendlyTabProps {
-      id: number;
-      url: string;
-      friendlyUrl: string;
-      title?: string;
-      favicon?: string;
-      active?: boolean;
-      engine?: string;
-    }
-
     const friendlyTablist: FriendlyTabProps[] = new Array();
     for (const tab of this.tablist) {
       console.log(tab);

--- a/src/backend/preload.ts
+++ b/src/backend/preload.ts
@@ -1,11 +1,7 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from "electron";
+import { HandlerPropsEvents } from "./types/index";
 
-interface HandlerProps {
-  event: string;
-  func: (event: IpcRendererEvent, tabs: object[]) => void;
-}
-
-const handlers: HandlerProps[] = [];
+const handlers: HandlerPropsEvents[] = [];
 
 contextBridge.exposeInMainWorld("ipc", {
   unload: () => {

--- a/src/backend/types/index.ts
+++ b/src/backend/types/index.ts
@@ -1,0 +1,32 @@
+import { BrowserView, IpcRendererEvent } from "electron";
+import Tablist from "../models/Tablist";
+
+export interface TabProps {
+  id: number;
+  url: string;
+  friendlyUrl: string;
+  view: BrowserView;
+  title?: string;
+  favicon?: string;
+  active?: boolean;
+  engine?: string;
+}
+
+export interface FriendlyTabProps {
+  id: number;
+  url: string;
+  friendlyUrl: string;
+  title?: string;
+  favicon?: string;
+  active?: boolean;
+  engine?: string;
+}
+
+export interface HandlerProps {
+  tablist: Tablist;
+}
+
+export interface HandlerPropsEvents {
+  event: string;
+  func: (event: IpcRendererEvent, tabs: object[]) => void;
+}


### PR DESCRIPTION
## Summary

This PR does not resolve any issue but for better development experience it is a good idea to keep types/interfaces seperated so they can be reused.

In Tab.ts on some events I defined the type (was not defined and caused errors on my IDE)
